### PR TITLE
Move ARC feature-check from header file to implementation file

### DIFF
--- a/iCloud/iCloud.h
+++ b/iCloud/iCloud.h
@@ -19,12 +19,6 @@
 // Import iCloudDocument
 #import <iCloud/iCloudDocument.h>
 
-// Check for ARC
-#if !__has_feature(objc_arc)
-    // Add the -fobjc-arc flag to enable ARC for only these files, as described in the ARC documentation: http://clang.llvm.org/docs/AutomaticReferenceCounting.html
-    #error iCloudDocumentSync is built with Objective-C ARC. You must enable ARC for iCloudDocumentSync.
-#endif
-
 // Ensure that the build is for iOS 5.1 or higher
 #ifndef __IPHONE_5_1
     #error iCloudDocumentSync is built with features only available is iOS SDK 5.1 and later.

--- a/iCloud/iCloud.m
+++ b/iCloud/iCloud.m
@@ -8,6 +8,12 @@
 
 #import "iCloud.h"
 
+// Check for ARC
+#if !__has_feature(objc_arc)
+// Add the -fobjc-arc flag to enable ARC for only these files, as described in the ARC documentation: http://clang.llvm.org/docs/AutomaticReferenceCounting.html
+#error iCloudDocumentSync is built with Objective-C ARC. You must enable ARC for iCloudDocumentSync.
+#endif
+
 @interface iCloud () {
     UIBackgroundTaskIdentifier backgroundProcess;
     NSFileManager *fileManager;


### PR DESCRIPTION
Previously feature-check in iCloud.h was falsely failing in a non-ARC project even when ARC was enabled for iCloud.m.
