### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ iCloud Document Sync is a great way to use iCloud document storage in your iOS a
   * [Contributions](#contributions)
   * [Sample App](#sample-app)
 * [**Installation**](#installation)
-  * [Cocoapods](#cocoapods-setup)
+  * [CocoaPods](#cocoapods-setup)
   * [Framework](#frameworks-setup)
   * [Traditional](#traditional-setup)
   * [Swift Projects](#swift-projects-setup)
@@ -63,7 +63,7 @@ The iOS Sample App included with this project demonstrates how to use many of th
 # Installation
 Adding iCloud Document Sync to your project is easy. There are multiple ways to add iCloud Document Sync to your project. Choose the process below which best suits your needs. Follow the steps to get everything up and running in only a few minutes.
 
-### Cocoapods Setup
+### CocoaPods Setup
 The easiest way to install iCloud Document Sync is to use CocoaPods. To do so, simply add the following line to your Podfile:
 
     pod 'iCloudDocumentSync'


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
