### PR TITLE
saveAndCloseDocumentWithName didn't save when iCloud not available.

### DIFF
--- a/iCloud/iCloud.m
+++ b/iCloud/iCloud.m
@@ -359,8 +359,9 @@
     // Log save
     if (self.verboseLogging == YES) NSLog(@"[iCloud] Beginning document save");
     
-    // Check for iCloud
-    if ([self quickCloudCheck] == NO) return;
+    // Don't Check for iCloud... we need to save the file
+    // regardless of being connected so that the saved file
+    // can be pushed to the cloud later on.
     
     // Check for nil / null document name
     if (documentName == nil || [documentName isEqualToString:@""]) {


### PR DESCRIPTION
When saveAndCloseDocumentWithName() is called, don't do the quickCloudCheck as that silently prevents the saving of the document to the local store. The save should go ahead, allowing iCloud to sync it when the connection is re-established later.