### PR TITLE
Optionally Suspend Updates

### DIFF
--- a/iCloud/iCloud.h
+++ b/iCloud/iCloud.h
@@ -92,7 +92,8 @@ NS_CLASS_AVAILABLE_IOS(6_0) @interface iCloud : NSObject
 /** Enable verbose availability logging for repeated feedback about iCloud availability in the log. Turning this off will prevent availability-related messages from being printed in the log. This property does not relate to the verboseLogging property. */
 @property BOOL verboseAvailabilityLogging;
 
-
+/** The current NSMetadataQuery object */
+@property BOOL ignoreUpdates;
 
 /** @name Checking for iCloud */
 

--- a/iCloud/iCloud.h
+++ b/iCloud/iCloud.h
@@ -67,7 +67,15 @@ NS_CLASS_AVAILABLE_IOS(6_0) @interface iCloud : NSObject
 - (void)setupiCloudDocumentSyncWithUbiquityContainer:(NSString *)containerID;
 
 
+/**
+ Temporarely pauses the updates queue in case you need to ensure a smooth UI.
+ 
+ @discussion The updates will be enqueued and performed when the flag is set to false again.
 
+ @param ignoreUpdates Control the supension of the updates queue.
+ */
+- (void)setSuspendUpdates:(BOOL)ignoreUpdates;
+    
 /** @name Delegate */
 
 /** iCloud Delegate helps call methods when document processes begin or end */
@@ -92,8 +100,7 @@ NS_CLASS_AVAILABLE_IOS(6_0) @interface iCloud : NSObject
 /** Enable verbose availability logging for repeated feedback about iCloud availability in the log. Turning this off will prevent availability-related messages from being printed in the log. This property does not relate to the verboseLogging property. */
 @property BOOL verboseAvailabilityLogging;
 
-/** The current NSMetadataQuery object */
-@property BOOL ignoreUpdates;
+
 
 /** @name Checking for iCloud */
 

--- a/iCloud/iCloud.m
+++ b/iCloud/iCloud.m
@@ -233,6 +233,9 @@
 }
 
 - (void)startUpdate:(NSNotification *)notification {
+    
+    if(self.ignoreUpdates) return;
+    
     // Log file update
     if (self.verboseLogging == YES) NSLog(@"[iCloud] Beginning file update with NSMetadataQuery");
     
@@ -244,6 +247,9 @@
 }
 
 - (void)recievedUpdate:(NSNotification *)notification {
+    
+    if(self.ignoreUpdates) return;
+    
     // Log file update
     if (self.verboseLogging == YES) NSLog(@"[iCloud] An update has been pushed from iCloud with NSMetadataQuery");
     
@@ -252,6 +258,9 @@
 }
 
 - (void)endUpdate:(NSNotification *)notification {
+    
+    if(self.ignoreUpdates) return;
+    
     // Get the updated files
     [self updateFiles];
     

--- a/iCloud/iCloud.m
+++ b/iCloud/iCloud.m
@@ -15,7 +15,7 @@
 #endif
 
 @interface iCloud ()
-
+@property (strong,nonatomic) NSOperationQueue *updatesQueue;
 @property (nonatomic, assign) UIBackgroundTaskIdentifier backgroundProcess;
 @property (nonatomic, strong) NSFileManager *fileManager;
 @property (nonatomic, strong) NSNotificationCenter *notificationCenter;
@@ -109,6 +109,28 @@
     // Log the setup
     NSLog(@"[iCloud] Initialized");
 }
+
+//---------------------------------------------------------------------------------------------------------------------------------------------//
+//------------ Queues --------------------------------------------------------------------------------------------------------------------------//
+//---------------------------------------------------------------------------------------------------------------------------------------------//
+#pragma mark - Queue
+
+-(void)setSuspendUpdates:(BOOL)ignoreUpdates{
+    self.updatesQueue.suspended = ignoreUpdates;
+}
+
+-(NSOperationQueue*)updatesQueue{
+    @synchronized(self){
+        
+        if(!_updatesQueue){
+            _updatesQueue = [NSOperationQueue new];
+            _updatesQueue.maxConcurrentOperationCount = 1;
+            _updatesQueue.qualityOfService = NSQualityOfServiceBackground;
+        }
+        return  _updatesQueue;
+    }
+}
+
 
 //---------------------------------------------------------------------------------------------------------------------------------------------//
 //------------ Basic --------------------------------------------------------------------------------------------------------------------------//
@@ -233,46 +255,50 @@
 }
 
 - (void)startUpdate:(NSNotification *)notification {
-    
-    if(self.ignoreUpdates) return;
-    
-    // Log file update
-    if (self.verboseLogging == YES) NSLog(@"[iCloud] Beginning file update with NSMetadataQuery");
-    
-    // Notify the delegate of the results on the main thread
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if ([self.delegate respondsToSelector:@selector(iCloudFileUpdateDidBegin)])
-            [self.delegate iCloudFileUpdateDidBegin];
-    });
+    __weak __typeof(self) wself=self;
+    [self.updatesQueue addOperationWithBlock:^{
+        // Log file update
+        if (wself.verboseLogging == YES) NSLog(@"[iCloud] Beginning file update with NSMetadataQuery");
+        
+        // Notify the delegate of the results on the main thread
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if ([wself.delegate respondsToSelector:@selector(iCloudFileUpdateDidBegin)])
+                [wself.delegate iCloudFileUpdateDidBegin];
+        });
+    }];
 }
 
 - (void)recievedUpdate:(NSNotification *)notification {
     
-    if(self.ignoreUpdates) return;
-    
-    // Log file update
-    if (self.verboseLogging == YES) NSLog(@"[iCloud] An update has been pushed from iCloud with NSMetadataQuery");
-    
-    // Get the updated files
-    [self updateFiles];
+    __weak __typeof(self) wself=self;
+    [self.updatesQueue addOperationWithBlock:^{
+        // Log file update
+        if (wself.verboseLogging == YES) NSLog(@"[iCloud] An update has been pushed from iCloud with NSMetadataQuery");
+        
+        // Get the updated files
+        [wself updateFiles];
+    }];
+   
 }
 
 - (void)endUpdate:(NSNotification *)notification {
     
-    if(self.ignoreUpdates) return;
-    
-    // Get the updated files
-    [self updateFiles];
-    
-    // Notify the delegate of the results on the main thread
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if ([self.delegate respondsToSelector:@selector(iCloudFileUpdateDidEnd)])
-            [self.delegate iCloudFileUpdateDidEnd];
-    });
-    
-    // Log query completion
-    if (self.verboseLogging == YES) NSLog(@"[iCloud] Finished file update with NSMetadataQuery");
+    __weak __typeof(self) wself=self;
+    [self.updatesQueue addOperationWithBlock:^{
+        // Get the updated files
+        [wself updateFiles];
+        
+        // Notify the delegate of the results on the main thread
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if ([wself.delegate respondsToSelector:@selector(iCloudFileUpdateDidEnd)])
+                [wself.delegate iCloudFileUpdateDidEnd];
+        });
+        
+        // Log query completion
+        if (wself.verboseLogging == YES) NSLog(@"[iCloud] Finished file update with NSMetadataQuery");
+    }];
 }
+     
 
 - (void)updateFiles {
     // Log file update


### PR DESCRIPTION
Hey guys!

We recently ran into an issue where the updates from iCloud where causing a CollectionView scroll to be sluggish. We tracked down to the callback caused after saving the document.

It seems like the problem is that after saving then the device gets an "echo" with the updates just pushed. While this redundancy might be fine for syncing having the ability to delay this update is important in order to keep the UI fluent.  This is especially true given the `receiveUpdate` callback triggers `updateFiles` that is resource intensive.

As a solution, we wrapped the update events into a single task operation queue and provided an accessor to suspend it when needed. The operation always gets enqueued and then processed at a later time when the suspension is released.


```
- (void)recievedUpdate:(NSNotification *)notification {
    
    __weak __typeof(self) wself=self;
    [self.updatesQueue addOperationWithBlock:^{
        // Log file update
        if (wself.verboseLogging == YES) NSLog(@"[iCloud] An update has been pushed from iCloud with NSMetadataQuery");
        
        // Get the updated files
        [wself updateFiles];
    }];
   
}
```

Please take a  look, it may come handy for other users!